### PR TITLE
Fix homepage when user has inactive job in his browse history

### DIFF
--- a/src/Service/JobHistoryService.php
+++ b/src/Service/JobHistoryService.php
@@ -60,7 +60,7 @@ class JobHistoryService
             $jobs[] = $jobRepository->findActiveJob($jobId);
         }
 
-        return $jobs;
+        return array_filter($jobs);
     }
 
     /**


### PR DESCRIPTION
Fixes #10 
`$jobRepository->findActiveJob($jobId)` returns `null` for inactive jobs. Filtered out inactive jobs from the result.